### PR TITLE
ci: default to the commit sha for a cache key if hashfiles is not goi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock, src/**/*') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock, src/**/*') }}
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock, **src/**/*') || github.sha }}
 
       - name: Build
         if: ${{ steps.cache-cargo-build.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
…ng to work...